### PR TITLE
fix mark1 demo

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,8 @@ from adapt.intent import IntentBuilder
 from mycroft import MycroftSkill, intent_handler
 from mycroft.skills.audioservice import AudioService
 from mycroft.audio import wait_while_speaking
+from mycroft.util import play_mp3
+
 
 class SingingSkill(MycroftSkill):
     def __init__(self):


### PR DESCRIPTION
bus message to sing used by mark1 demo was broken

import of play_mp3 was removed when skill was changed to use audio service

this PR does the bare minimum to make things functional

future work:
- also use audio service on bus message instead of play_mp3
- stop depends on play_mp3, should check what is playing on audio service
- allow selecting song on bus message? demo skill would also need changing