### PR TITLE
new method for detecting audio.service.stop Message

### DIFF
--- a/test/behave/steps/singing_steps.py
+++ b/test/behave/steps/singing_steps.py
@@ -39,12 +39,16 @@ def given_nothing_playing(context):
 
 @then('mycroft should sing')
 def then_playback_start(context):
-    cnt = 0
-    while context.bus.get_messages('mycroft.audio.service.play') == []:
-        if cnt > 20:
-            assert False, 'Mycroft didn\'t start singing :('
-            break
-        time.sleep(0.5)
+    def check_for_play(message):
+        return (message.msg_type == 'mycroft.audio.service.play', '')
+
+    passed, debug = then_wait('mycroft.audio.service.play', check_for_play,
+                              context)
+    if not passed:
+        assert_msg = debug
+        assert_msg += mycroft_responses(context)
+
+    assert passed, assert_msg or "Mycroft didn't start singing"
 
 
 @then('mycroft should stop singing')


### PR DESCRIPTION
Wondering if this method will be more reliable at detecting the stop message for VK tests?

Technically `check_for_stop` could just return True since only `mycroft.audio.service.stop` Messages should get passed in, but I thought the return comparison made it slightly more explicit.