### PR TITLE
add missing VK import

### DIFF
--- a/test/behave/steps/singing_steps.py
+++ b/test/behave/steps/singing_steps.py
@@ -18,7 +18,7 @@ from behave import given, then
 
 from mycroft.audio import wait_while_speaking
 
-from test.integrationtests.voight_kampff import emit_utterance, wait_for_dialog, then_wait
+from test.integrationtests.voight_kampff import emit_utterance, mycroft_responses, then_wait, wait_for_dialog
 
 
 @given('mycroft is singing')


### PR DESCRIPTION
Forgot an extra Voight Kampff import with the last changes.

This adds the mycroft-responses method to provide feedback on what Mycroft did respond with in the case of a test failure.