### PR TITLE
Improve check for is singing

### DIFF
--- a/test/behave/steps/singing_steps.py
+++ b/test/behave/steps/singing_steps.py
@@ -16,16 +16,36 @@ import time
 
 from behave import given, then
 
-from mycroft.audio import wait_while_speaking
+from test.integrationtests.voight_kampff import (
+    emit_utterance,
+    mycroft_responses,
+    then_wait
+)
 
-from test.integrationtests.voight_kampff import emit_utterance, mycroft_responses, then_wait, wait_for_dialog
+
+def wait_for_service_message(context, message_type):
+    """Common method for detecting audio play, stop, or pause messages"""
+    msg_type = 'mycroft.audio.service.{}'.format(message_type)
+
+    def check_for_msg(message):
+        return (message.msg_type == msg_type, '')
+
+    passed, debug = then_wait(msg_type, check_for_msg, context)
+
+    if not passed:
+        debug += mycroft_responses(context)
+    if not debug:
+        if message_type == 'play':
+            message_type = 'start'
+        debug = "Mycroft didn't {} playback".format(message_type)
+
+    assert passed, debug
 
 
 @given('mycroft is singing')
 def given_news_playing(context):
     emit_utterance(context.bus, "sing a song")
-    wait_for_dialog(context.bus, ['singing'])
-    wait_while_speaking()
+    wait_for_service_message(context, 'play')
     time.sleep(3)
     context.bus.clear_messages()
 


### PR DESCRIPTION
#### Description
This is an attempt to get the skill tester to work more consistently with the singing skill. This changes to use the same check as in npr-news verifying that audioservice play is sent instead of waiting for dialog.

#### Type of PR
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ x ] Test improvements

#### Testing
Test in VK to see that the tests still pass.